### PR TITLE
copy logic from original flat-tree iterator

### DIFF
--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,10 +1,10 @@
 //! ## Usage
 //! ```rust
 //! let mut iter = flat_tree::Iterator::new(0);
-//! assert_eq!(iter.next(), Some(0));
-//! assert_eq!(iter.next(), Some(1));
 //! assert_eq!(iter.next(), Some(2));
-//! assert_eq!(iter.parent(), 7);
+//! assert_eq!(iter.next(), Some(4));
+//! assert_eq!(iter.next(), Some(6));
+//! assert_eq!(iter.parent(), 5);
 //! ```
 use super::*;
 
@@ -26,10 +26,7 @@ impl Iterator {
       factor: 0,
     };
 
-    if index != 0 {
-      instance.seek(index);
-    }
-
+    instance.seek(index);
     instance
   }
 
@@ -42,7 +39,7 @@ impl Iterator {
   /// Seek to a position in the iterator.
   pub fn seek(&mut self, index: usize) {
     self.index = index;
-    if (self.index & 1) > 0 {
+    if is_odd(self.index) {
       self.offset = offset(index);
       self.factor = two_pow(depth(index) + 1);
     } else {
@@ -53,14 +50,14 @@ impl Iterator {
 
   /// Check if the position of the iterator is currently on a left node.
   #[inline]
-  pub fn is_left(&mut self) -> bool {
-    (self.offset & 1) == 0
+  pub fn is_left(&self) -> bool {
+    is_even(self.offset)
   }
 
   /// Check if the position of the iterator is currently on a right node.
   #[inline]
-  pub fn is_right(&mut self) -> bool {
-    !self.is_left()
+  pub fn is_right(&self) -> bool {
+    is_odd(self.offset)
   }
 
   /// Move the cursor and get the previous item from the current position.
@@ -76,7 +73,7 @@ impl Iterator {
   /// Get the sibling for the current position and move the cursor.
   pub fn sibling(&mut self) -> usize {
     if self.is_left() {
-      self.next().unwrap() // We always have a future value.
+      self.next().unwrap() // this is always safe
     } else {
       self.prev()
     }
@@ -90,14 +87,15 @@ impl Iterator {
 
   /// Get the parent for the current position and move the cursor.
   pub fn parent(&mut self) -> usize {
-    if self.offset & 1 > 0 {
+    if is_odd(self.offset) {
       self.index -= self.factor / 2;
-      self.offset = self.offset - 1 / 2;
+      self.offset -= 1 / 2;
     } else {
       self.index += self.factor / 2;
       self.offset /= 2;
     }
     self.factor *= 2;
+    println!("{}", self.index);
     self.index
   }
 
@@ -144,9 +142,15 @@ impl iter::Iterator for Iterator {
   type Item = usize;
 
   fn next(&mut self) -> Option<Self::Item> {
-    self.index += 1;
+    self.offset += 1;
     self.index += self.factor;
     Some(self.index)
+  }
+}
+
+impl Default for Iterator {
+  fn default() -> Self {
+    Self::new(0)
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,7 +349,7 @@ pub fn full_roots(i: usize, nodes: &mut Vec<usize>) {
 }
 
 #[inline]
-fn is_even(num: usize) -> bool {
+pub(crate) fn is_even(num: usize) -> bool {
   (num & 1) == 0
 }
 #[test]
@@ -361,7 +361,7 @@ fn test_is_even() {
 }
 
 #[inline]
-fn is_odd(num: usize) -> bool {
+pub(crate) fn is_odd(num: usize) -> bool {
   (num & 1) != 0
 }
 #[test]

--- a/tests/iterator.rs
+++ b/tests/iterator.rs
@@ -12,3 +12,15 @@ fn iterator() {
   assert_eq!(iterator.next(), Some(13));
   assert_eq!(iterator.left_span(), 12);
 }
+
+#[test]
+fn non_leaf_start() {
+  let mut iterator = flat_tree::Iterator::new(1);
+  assert_eq!(iterator.index(), 1);
+  assert_eq!(iterator.parent(), 3);
+  assert_eq!(iterator.parent(), 7);
+  assert_eq!(iterator.right_child(), 11);
+  assert_eq!(iterator.left_child(), 9);
+  assert_eq!(iterator.next(), Some(13));
+  assert_eq!(iterator.left_span(), 12);
+}

--- a/tests/iterator.rs
+++ b/tests/iterator.rs
@@ -1,0 +1,14 @@
+extern crate flat_tree;
+
+#[test]
+fn iterator() {
+  let mut iterator = flat_tree::Iterator::default();
+  assert_eq!(iterator.index(), 0);
+  assert_eq!(iterator.parent(), 1);
+  assert_eq!(iterator.parent(), 3);
+  assert_eq!(iterator.parent(), 7);
+  assert_eq!(iterator.right_child(), 11);
+  assert_eq!(iterator.left_child(), 9);
+  assert_eq!(iterator.next(), Some(13));
+  assert_eq!(iterator.left_span(), 12);
+}


### PR DESCRIPTION
Does a 1:1 mapping of the original logic to this module. Was missing some methods for hypercore, and this'll fix it. semver major.