### PR TITLE
Remove deprecated clippy compiler plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
 before_script: |
   rustup component add rustfmt-preview
 script: |
-  cargo fmt -- --write-mode=diff &&
+  cargo fmt -- --check || true &&
   cargo build --verbose &&
   cargo test  --verbose
 cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,3 @@ repository = "https://github.com/mafintosh/flat-tree-rs"
 keywords = ["flat", "tree", "binary"]
 readme = "README.md"
 license = "MIT"
-
-[dev-dependencies]
-clippy = "0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,10 +124,7 @@ pub fn children_with_depth(i: usize, depth: usize) -> Option<(usize, usize)> {
     Some((i, i))
   } else {
     let offset = offset_with_depth(i, depth) * 2;
-    Some((
-      index(depth - 1, offset),
-      index(depth - 1, offset + 1),
-    ))
+    Some((index(depth - 1, offset), index(depth - 1, offset + 1)))
   }
 }
 
@@ -152,10 +149,7 @@ pub fn left_child_with_depth(i: usize, depth: usize) -> Option<usize> {
   } else if depth == 0 {
     Some(i)
   } else {
-    Some(index(
-      depth - 1,
-      offset_with_depth(i, depth) << 1,
-    ))
+    Some(index(depth - 1, offset_with_depth(i, depth) << 1))
   }
 }
 
@@ -178,10 +172,7 @@ pub fn right_child_with_depth(i: usize, depth: usize) -> Option<usize> {
   } else if depth == 0 {
     Some(i)
   } else {
-    Some(index(
-      depth - 1,
-      (offset_with_depth(i, depth) << 1) + 1,
-    ))
+    Some(index(depth - 1, (offset_with_depth(i, depth) << 1) + 1))
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 #![deny(missing_docs)]
 #![feature(external_doc)]
 #![doc(include = "../README.md")]
-#![cfg_attr(test, feature(plugin))]
-#![cfg_attr(test, plugin(clippy))]
 
 mod iterator;
 


### PR DESCRIPTION
Both of these are necessary to make it compile.

Note: rustfmt will not fail the build if the source needs formatting (same as before).

Clippy is currently broken, so it's excluded entirely.