### PR TITLE
Specify nightly in feature directives

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-#![deny(missing_docs)]
-#![feature(external_doc)]
-#![doc(include = "../README.md")]
+#![cfg_attr(feature = "nightly", deny(missing_docs))]
+#![cfg_attr(feature = "nightly", feature(external_doc))]
+#![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 
 mod iterator;
 


### PR DESCRIPTION
Resolves #32 and allows flat-tree to be built from the stable release channel.