### PR TITLE
Add missing doctests and add debug_assert to `*_with_depth` functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub fn depth(i: usize) -> usize {
 /// assert_eq!(flat_tree::offset_with_depth(4, 0), 2);
 /// ```
 pub fn offset_with_depth(i: usize, depth: usize) -> usize {
-  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   if is_even(i) {
     i / 2
   } else {
@@ -88,7 +88,7 @@ pub fn offset(i: usize) -> usize {
 /// assert_eq!(flat_tree::parent_with_depth(4, 0), 5);
 /// ```
 pub fn parent_with_depth(i: usize, depth: usize) -> usize {
-  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   index(depth + 1, offset_with_depth(i, depth) >> 1)
 }
 
@@ -119,7 +119,7 @@ pub fn parent(i: usize) -> usize {
 /// assert_eq!(flat_tree::sibling_with_depth(4, 0), 6);
 /// ```
 pub fn sibling_with_depth(i: usize, depth: usize) -> usize {
-  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   index(depth, offset(i) ^ 1)
 }
 
@@ -146,7 +146,7 @@ pub fn sibling(i: usize) -> usize {
 /// assert_eq!(flat_tree::uncle_with_depth(5, 1), 11);
 /// ```
 pub fn uncle_with_depth(i: usize, depth: usize) -> usize {
-  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   sibling_with_depth(parent_with_depth(i, depth), depth + 1)
 }
 
@@ -173,7 +173,7 @@ pub fn uncle(i: usize) -> usize {
 /// assert_eq!(flat_tree::children_with_depth(9, 1), Some((8, 10)));
 /// ```
 pub fn children_with_depth(i: usize, depth: usize) -> Option<(usize, usize)> {
-  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   if is_even(i) {
     None
   } else if depth == 0 {
@@ -207,7 +207,7 @@ pub fn children(i: usize) -> Option<(usize, usize)> {
 /// ```
 // TODO: handle errors
 pub fn left_child_with_depth(i: usize, depth: usize) -> Option<usize> {
-  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   if is_even(i) {
     None
   } else if depth == 0 {
@@ -238,7 +238,7 @@ pub fn left_child(i: usize) -> Option<usize> {
 /// assert_eq!(flat_tree::right_child_with_depth(3, 2), Some(5));
 /// ```
 pub fn right_child_with_depth(i: usize, depth: usize) -> Option<usize> {
-  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   if is_even(i) {
     None
   } else if depth == 0 {
@@ -272,7 +272,7 @@ pub fn right_child(i: usize) -> Option<usize> {
 /// assert_eq!(flat_tree::right_span_with_depth(27, 2), 30);
 /// ```
 pub fn right_span_with_depth(i: usize, depth: usize) -> usize {
-  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   if depth == 0 {
     i
   } else {
@@ -305,7 +305,7 @@ pub fn right_span(i: usize) -> usize {
 /// assert_eq!(flat_tree::left_span_with_depth(27, 2), 24);
 /// ```
 pub fn left_span_with_depth(i: usize, depth: usize) -> usize {
-  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   if depth == 0 {
     i
   } else {
@@ -339,7 +339,7 @@ pub fn left_span(i: usize) -> usize {
 /// assert_eq!(flat_tree::spans_with_depth(27, 2), (24, 30));
 /// ```
 pub fn spans_with_depth(i: usize, depth: usize) -> (usize, usize) {
-  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   (
     left_span_with_depth(i, depth),
     right_span_with_depth(i, depth),
@@ -372,7 +372,7 @@ pub fn spans(i: usize) -> (usize, usize) {
 /// assert_eq!(flat_tree::count_with_depth(27, 2), 7);
 /// ```
 pub fn count_with_depth(i: usize, depth: usize) -> usize {
-  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   (2 << depth) - 1
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub fn depth(i: usize) -> usize {
 /// assert_eq!(flat_tree::offset_with_depth(4, 0), 2);
 /// ```
 pub fn offset_with_depth(i: usize, depth: usize) -> usize {
-  debug_assert_eq!(depth, self::depth(i));
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
   if is_even(i) {
     i / 2
   } else {
@@ -88,7 +88,7 @@ pub fn offset(i: usize) -> usize {
 /// assert_eq!(flat_tree::parent_with_depth(4, 0), 5);
 /// ```
 pub fn parent_with_depth(i: usize, depth: usize) -> usize {
-  debug_assert_eq!(depth, self::depth(i));
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
   index(depth + 1, offset_with_depth(i, depth) >> 1)
 }
 
@@ -119,7 +119,7 @@ pub fn parent(i: usize) -> usize {
 /// assert_eq!(flat_tree::sibling_with_depth(4, 0), 6);
 /// ```
 pub fn sibling_with_depth(i: usize, depth: usize) -> usize {
-  debug_assert_eq!(depth, self::depth(i));
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
   index(depth, offset(i) ^ 1)
 }
 
@@ -146,7 +146,7 @@ pub fn sibling(i: usize) -> usize {
 /// assert_eq!(flat_tree::uncle_with_depth(5, 1), 11);
 /// ```
 pub fn uncle_with_depth(i: usize, depth: usize) -> usize {
-  debug_assert_eq!(depth, self::depth(i));
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
   sibling_with_depth(parent_with_depth(i, depth), depth + 1)
 }
 
@@ -173,7 +173,7 @@ pub fn uncle(i: usize) -> usize {
 /// assert_eq!(flat_tree::children_with_depth(9, 1), Some((8, 10)));
 /// ```
 pub fn children_with_depth(i: usize, depth: usize) -> Option<(usize, usize)> {
-  debug_assert_eq!(depth, self::depth(i));
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
   if is_even(i) {
     None
   } else if depth == 0 {
@@ -207,7 +207,7 @@ pub fn children(i: usize) -> Option<(usize, usize)> {
 /// ```
 // TODO: handle errors
 pub fn left_child_with_depth(i: usize, depth: usize) -> Option<usize> {
-  debug_assert_eq!(depth, self::depth(i));
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
   if is_even(i) {
     None
   } else if depth == 0 {
@@ -238,7 +238,7 @@ pub fn left_child(i: usize) -> Option<usize> {
 /// assert_eq!(flat_tree::right_child_with_depth(3, 2), Some(5));
 /// ```
 pub fn right_child_with_depth(i: usize, depth: usize) -> Option<usize> {
-  debug_assert_eq!(depth, self::depth(i));
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
   if is_even(i) {
     None
   } else if depth == 0 {
@@ -272,7 +272,7 @@ pub fn right_child(i: usize) -> Option<usize> {
 /// assert_eq!(flat_tree::right_span_with_depth(27, 2), 30);
 /// ```
 pub fn right_span_with_depth(i: usize, depth: usize) -> usize {
-  debug_assert_eq!(depth, self::depth(i));
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
   if depth == 0 {
     i
   } else {
@@ -305,7 +305,7 @@ pub fn right_span(i: usize) -> usize {
 /// assert_eq!(flat_tree::left_span_with_depth(27, 2), 24);
 /// ```
 pub fn left_span_with_depth(i: usize, depth: usize) -> usize {
-  debug_assert_eq!(depth, self::depth(i));
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
   if depth == 0 {
     i
   } else {
@@ -339,7 +339,7 @@ pub fn left_span(i: usize) -> usize {
 /// assert_eq!(flat_tree::spans_with_depth(27, 2), (24, 30));
 /// ```
 pub fn spans_with_depth(i: usize, depth: usize) -> (usize, usize) {
-  debug_assert_eq!(depth, self::depth(i));
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
   (
     left_span_with_depth(i, depth),
     right_span_with_depth(i, depth),
@@ -372,7 +372,7 @@ pub fn spans(i: usize) -> (usize, usize) {
 /// assert_eq!(flat_tree::count_with_depth(27, 2), 7);
 /// ```
 pub fn count_with_depth(i: usize, depth: usize) -> usize {
-  debug_assert_eq!(depth, self::depth(i));
+  debug_assert_eq!(depth, self::depth(i), "Invalid depth!");
   (2 << depth) - 1
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,15 @@ pub fn depth(i: usize) -> usize {
 }
 
 /// Returns the offset of a node with a depth.
+///
+/// ## Examples
+/// ```rust
+/// assert_eq!(flat_tree::offset_with_depth(0, 0), 0);
+/// assert_eq!(flat_tree::offset_with_depth(1, 1), 0);
+/// assert_eq!(flat_tree::offset_with_depth(2, 0), 1);
+/// assert_eq!(flat_tree::offset_with_depth(3, 2), 0);
+/// assert_eq!(flat_tree::offset_with_depth(4, 0), 2);
+/// ```
 pub fn offset_with_depth(i: usize, depth: usize) -> usize {
   debug_assert_eq!(depth, self::depth(i));
   if is_even(i) {
@@ -69,6 +78,15 @@ pub fn offset(i: usize) -> usize {
 }
 
 /// Returns the parent of a node with a depth.
+///
+/// ## Examples
+/// ```rust
+/// assert_eq!(flat_tree::parent_with_depth(0, 0), 1);
+/// assert_eq!(flat_tree::parent_with_depth(1, 1), 3);
+/// assert_eq!(flat_tree::parent_with_depth(2, 0), 1);
+/// assert_eq!(flat_tree::parent_with_depth(3, 2), 7);
+/// assert_eq!(flat_tree::parent_with_depth(4, 0), 5);
+/// ```
 pub fn parent_with_depth(i: usize, depth: usize) -> usize {
   debug_assert_eq!(depth, self::depth(i));
   index(depth + 1, offset_with_depth(i, depth) >> 1)
@@ -91,6 +109,15 @@ pub fn parent(i: usize) -> usize {
 }
 
 /// Returns the sibling of a node with a depth.
+///
+/// ## Examples
+/// ```rust
+/// assert_eq!(flat_tree::sibling_with_depth(0, 0), 2);
+/// assert_eq!(flat_tree::sibling_with_depth(1, 1), 5);
+/// assert_eq!(flat_tree::sibling_with_depth(2, 0), 0);
+/// assert_eq!(flat_tree::sibling_with_depth(3, 2), 11);
+/// assert_eq!(flat_tree::sibling_with_depth(4, 0), 6);
+/// ```
 pub fn sibling_with_depth(i: usize, depth: usize) -> usize {
   debug_assert_eq!(depth, self::depth(i));
   index(depth, offset(i) ^ 1)
@@ -110,6 +137,14 @@ pub fn sibling(i: usize) -> usize {
 }
 
 /// Returns the parent's sibling, of a node, with a depth.
+///
+/// ## Examples
+/// ```rust
+/// assert_eq!(flat_tree::uncle_with_depth(0, 0), 5);
+/// assert_eq!(flat_tree::uncle_with_depth(1, 1), 11);
+/// assert_eq!(flat_tree::uncle_with_depth(2, 0), 5);
+/// assert_eq!(flat_tree::uncle_with_depth(5, 1), 11);
+/// ```
 pub fn uncle_with_depth(i: usize, depth: usize) -> usize {
   debug_assert_eq!(depth, self::depth(i));
   sibling_with_depth(parent_with_depth(i, depth), depth + 1)
@@ -129,6 +164,14 @@ pub fn uncle(i: usize) -> usize {
 }
 
 /// Returns both children of a node, with a depth.
+///
+/// ## Examples
+/// ```rust
+/// assert_eq!(flat_tree::children_with_depth(0, 0), None);
+/// assert_eq!(flat_tree::children_with_depth(1, 1), Some((0, 2)));
+/// assert_eq!(flat_tree::children_with_depth(3, 2), Some((1, 5)));
+/// assert_eq!(flat_tree::children_with_depth(9, 1), Some((8, 10)));
+/// ```
 pub fn children_with_depth(i: usize, depth: usize) -> Option<(usize, usize)> {
   debug_assert_eq!(depth, self::depth(i));
   if is_even(i) {
@@ -155,6 +198,13 @@ pub fn children(i: usize) -> Option<(usize, usize)> {
 }
 
 /// Returns only the left child of a node, with a depth
+///
+/// ## Examples
+/// ```rust
+/// assert_eq!(flat_tree::left_child_with_depth(0, 0), None);
+/// assert_eq!(flat_tree::left_child_with_depth(1, 1), Some(0));
+/// assert_eq!(flat_tree::left_child_with_depth(3, 2), Some(1));
+/// ```
 // TODO: handle errors
 pub fn left_child_with_depth(i: usize, depth: usize) -> Option<usize> {
   debug_assert_eq!(depth, self::depth(i));
@@ -180,6 +230,13 @@ pub fn left_child(i: usize) -> Option<usize> {
 }
 
 /// Returns only the left child of a node, with a depth.
+///
+/// ## Examples
+/// ```rust
+/// assert_eq!(flat_tree::right_child_with_depth(0, 0), None);
+/// assert_eq!(flat_tree::right_child_with_depth(1, 1), Some(2));
+/// assert_eq!(flat_tree::right_child_with_depth(3, 2), Some(5));
+/// ```
 pub fn right_child_with_depth(i: usize, depth: usize) -> Option<usize> {
   debug_assert_eq!(depth, self::depth(i));
   if is_even(i) {
@@ -205,6 +262,15 @@ pub fn right_child(i: usize) -> Option<usize> {
 }
 
 /// Returns the right most node in the tree that the node spans, with a depth.
+///
+/// ## Examples
+/// ```rust
+/// assert_eq!(flat_tree::right_span_with_depth(0, 0), 0);
+/// assert_eq!(flat_tree::right_span_with_depth(1, 1), 2);
+/// assert_eq!(flat_tree::right_span_with_depth(3, 2), 6);
+/// assert_eq!(flat_tree::right_span_with_depth(23, 3), 30);
+/// assert_eq!(flat_tree::right_span_with_depth(27, 2), 30);
+/// ```
 pub fn right_span_with_depth(i: usize, depth: usize) -> usize {
   debug_assert_eq!(depth, self::depth(i));
   if depth == 0 {
@@ -229,6 +295,15 @@ pub fn right_span(i: usize) -> usize {
 }
 
 /// Returns the left most node in the tree that the node spans, with a depth.
+///
+/// ## Examples
+/// ```rust
+/// assert_eq!(flat_tree::left_span_with_depth(0, 0), 0);
+/// assert_eq!(flat_tree::left_span_with_depth(1, 1), 0);
+/// assert_eq!(flat_tree::left_span_with_depth(3, 2), 0);
+/// assert_eq!(flat_tree::left_span_with_depth(23, 3), 16);
+/// assert_eq!(flat_tree::left_span_with_depth(27, 2), 24);
+/// ```
 pub fn left_span_with_depth(i: usize, depth: usize) -> usize {
   debug_assert_eq!(depth, self::depth(i));
   if depth == 0 {
@@ -254,6 +329,15 @@ pub fn left_span(i: usize) -> usize {
 
 /// Returns the left and right most nodes in the tree that the node spans, with
 /// a depth.
+///
+/// ## Examples
+/// ```rust
+/// assert_eq!(flat_tree::spans_with_depth(0, 0), (0, 0));
+/// assert_eq!(flat_tree::spans_with_depth(1, 1), (0, 2));
+/// assert_eq!(flat_tree::spans_with_depth(3, 2), (0, 6));
+/// assert_eq!(flat_tree::spans_with_depth(23, 3), (16, 30));
+/// assert_eq!(flat_tree::spans_with_depth(27, 2), (24, 30));
+/// ```
 pub fn spans_with_depth(i: usize, depth: usize) -> (usize, usize) {
   debug_assert_eq!(depth, self::depth(i));
   (
@@ -277,6 +361,16 @@ pub fn spans(i: usize) -> (usize, usize) {
 }
 
 /// Returns how many nodes are in the tree that the node spans, with a depth.
+///
+/// ## Examples
+/// ```rust
+/// assert_eq!(flat_tree::count_with_depth(0, 0), 1);
+/// assert_eq!(flat_tree::count_with_depth(1, 1), 3);
+/// assert_eq!(flat_tree::count_with_depth(3, 2), 7);
+/// assert_eq!(flat_tree::count_with_depth(5, 1), 3);
+/// assert_eq!(flat_tree::count_with_depth(23, 3), 15);
+/// assert_eq!(flat_tree::count_with_depth(27, 2), 7);
+/// ```
 pub fn count_with_depth(i: usize, depth: usize) -> usize {
   debug_assert_eq!(depth, self::depth(i));
   (2 << depth) - 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,8 @@ pub fn depth(i: usize) -> usize {
 }
 
 /// Returns the offset of a node with a depth.
-fn offset_with_depth(i: usize, depth: usize) -> usize {
+pub fn offset_with_depth(i: usize, depth: usize) -> usize {
+  debug_assert_eq!(depth, self::depth(i));
   if is_even(i) {
     i / 2
   } else {
@@ -68,7 +69,8 @@ pub fn offset(i: usize) -> usize {
 }
 
 /// Returns the parent of a node with a depth.
-fn parent_with_depth(i: usize, depth: usize) -> usize {
+pub fn parent_with_depth(i: usize, depth: usize) -> usize {
+  debug_assert_eq!(depth, self::depth(i));
   index(depth + 1, offset_with_depth(i, depth) >> 1)
 }
 
@@ -89,7 +91,8 @@ pub fn parent(i: usize) -> usize {
 }
 
 /// Returns the sibling of a node with a depth.
-fn sibling_with_depth(i: usize, depth: usize) -> usize {
+pub fn sibling_with_depth(i: usize, depth: usize) -> usize {
+  debug_assert_eq!(depth, self::depth(i));
   index(depth, offset(i) ^ 1)
 }
 
@@ -107,7 +110,8 @@ pub fn sibling(i: usize) -> usize {
 }
 
 /// Returns the parent's sibling, of a node, with a depth.
-fn uncle_with_depth(i: usize, depth: usize) -> usize {
+pub fn uncle_with_depth(i: usize, depth: usize) -> usize {
+  debug_assert_eq!(depth, self::depth(i));
   sibling_with_depth(parent_with_depth(i, depth), depth + 1)
 }
 
@@ -125,7 +129,8 @@ pub fn uncle(i: usize) -> usize {
 }
 
 /// Returns both children of a node, with a depth.
-fn children_with_depth(i: usize, depth: usize) -> Option<(usize, usize)> {
+pub fn children_with_depth(i: usize, depth: usize) -> Option<(usize, usize)> {
+  debug_assert_eq!(depth, self::depth(i));
   if is_even(i) {
     None
   } else if depth == 0 {
@@ -151,7 +156,8 @@ pub fn children(i: usize) -> Option<(usize, usize)> {
 
 /// Returns only the left child of a node, with a depth
 // TODO: handle errors
-fn left_child_with_depth(i: usize, depth: usize) -> Option<usize> {
+pub fn left_child_with_depth(i: usize, depth: usize) -> Option<usize> {
+  debug_assert_eq!(depth, self::depth(i));
   if is_even(i) {
     None
   } else if depth == 0 {
@@ -174,7 +180,8 @@ pub fn left_child(i: usize) -> Option<usize> {
 }
 
 /// Returns only the left child of a node, with a depth.
-fn right_child_with_depth(i: usize, depth: usize) -> Option<usize> {
+pub fn right_child_with_depth(i: usize, depth: usize) -> Option<usize> {
+  debug_assert_eq!(depth, self::depth(i));
   if is_even(i) {
     None
   } else if depth == 0 {
@@ -198,7 +205,8 @@ pub fn right_child(i: usize) -> Option<usize> {
 }
 
 /// Returns the right most node in the tree that the node spans, with a depth.
-fn right_span_with_depth(i: usize, depth: usize) -> usize {
+pub fn right_span_with_depth(i: usize, depth: usize) -> usize {
+  debug_assert_eq!(depth, self::depth(i));
   if depth == 0 {
     i
   } else {
@@ -221,7 +229,8 @@ pub fn right_span(i: usize) -> usize {
 }
 
 /// Returns the left most node in the tree that the node spans, with a depth.
-fn left_span_with_depth(i: usize, depth: usize) -> usize {
+pub fn left_span_with_depth(i: usize, depth: usize) -> usize {
+  debug_assert_eq!(depth, self::depth(i));
   if depth == 0 {
     i
   } else {
@@ -245,7 +254,8 @@ pub fn left_span(i: usize) -> usize {
 
 /// Returns the left and right most nodes in the tree that the node spans, with
 /// a depth.
-fn spans_with_depth(i: usize, depth: usize) -> (usize, usize) {
+pub fn spans_with_depth(i: usize, depth: usize) -> (usize, usize) {
+  debug_assert_eq!(depth, self::depth(i));
   (
     left_span_with_depth(i, depth),
     right_span_with_depth(i, depth),
@@ -267,7 +277,8 @@ pub fn spans(i: usize) -> (usize, usize) {
 }
 
 /// Returns how many nodes are in the tree that the node spans, with a depth.
-fn count_with_depth(_: usize, depth: usize) -> usize {
+pub fn count_with_depth(i: usize, depth: usize) -> usize {
+  debug_assert_eq!(depth, self::depth(i));
   (2 << depth) - 1
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub fn depth(i: usize) -> usize {
 }
 
 /// Returns the offset of a node with a depth.
-pub fn offset_with_depth(i: usize, depth: usize) -> usize {
+fn offset_with_depth(i: usize, depth: usize) -> usize {
   if is_even(i) {
     i / 2
   } else {
@@ -68,7 +68,7 @@ pub fn offset(i: usize) -> usize {
 }
 
 /// Returns the parent of a node with a depth.
-pub fn parent_with_depth(i: usize, depth: usize) -> usize {
+fn parent_with_depth(i: usize, depth: usize) -> usize {
   index(depth + 1, offset_with_depth(i, depth) >> 1)
 }
 
@@ -89,7 +89,7 @@ pub fn parent(i: usize) -> usize {
 }
 
 /// Returns the sibling of a node with a depth.
-pub fn sibling_with_depth(i: usize, depth: usize) -> usize {
+fn sibling_with_depth(i: usize, depth: usize) -> usize {
   index(depth, offset(i) ^ 1)
 }
 
@@ -107,17 +107,25 @@ pub fn sibling(i: usize) -> usize {
 }
 
 /// Returns the parent's sibling, of a node, with a depth.
-pub fn uncle_with_depth(i: usize, depth: usize) -> usize {
+fn uncle_with_depth(i: usize, depth: usize) -> usize {
   sibling_with_depth(parent_with_depth(i, depth), depth + 1)
 }
 
 /// Returns the parent's sibling, of a node.
+///
+/// ## Examples
+/// ```rust
+/// assert_eq!(flat_tree::uncle(0), 5);
+/// assert_eq!(flat_tree::uncle(2), 5);
+/// assert_eq!(flat_tree::uncle(1), 11);
+/// assert_eq!(flat_tree::uncle(5), 11);
+/// ```
 pub fn uncle(i: usize) -> usize {
   uncle_with_depth(i, depth(i))
 }
 
 /// Returns both children of a node, with a depth.
-pub fn children_with_depth(i: usize, depth: usize) -> Option<(usize, usize)> {
+fn children_with_depth(i: usize, depth: usize) -> Option<(usize, usize)> {
   if is_even(i) {
     None
   } else if depth == 0 {
@@ -143,7 +151,7 @@ pub fn children(i: usize) -> Option<(usize, usize)> {
 
 /// Returns only the left child of a node, with a depth
 // TODO: handle errors
-pub fn left_child_with_depth(i: usize, depth: usize) -> Option<usize> {
+fn left_child_with_depth(i: usize, depth: usize) -> Option<usize> {
   if is_even(i) {
     None
   } else if depth == 0 {
@@ -166,7 +174,7 @@ pub fn left_child(i: usize) -> Option<usize> {
 }
 
 /// Returns only the left child of a node, with a depth.
-pub fn right_child_with_depth(i: usize, depth: usize) -> Option<usize> {
+fn right_child_with_depth(i: usize, depth: usize) -> Option<usize> {
   if is_even(i) {
     None
   } else if depth == 0 {
@@ -190,7 +198,7 @@ pub fn right_child(i: usize) -> Option<usize> {
 }
 
 /// Returns the right most node in the tree that the node spans, with a depth.
-pub fn right_span_with_depth(i: usize, depth: usize) -> usize {
+fn right_span_with_depth(i: usize, depth: usize) -> usize {
   if depth == 0 {
     i
   } else {
@@ -213,7 +221,7 @@ pub fn right_span(i: usize) -> usize {
 }
 
 /// Returns the left most node in the tree that the node spans, with a depth.
-pub fn left_span_with_depth(i: usize, depth: usize) -> usize {
+fn left_span_with_depth(i: usize, depth: usize) -> usize {
   if depth == 0 {
     i
   } else {
@@ -237,7 +245,7 @@ pub fn left_span(i: usize) -> usize {
 
 /// Returns the left and right most nodes in the tree that the node spans, with
 /// a depth.
-pub fn spans_with_depth(i: usize, depth: usize) -> (usize, usize) {
+fn spans_with_depth(i: usize, depth: usize) -> (usize, usize) {
   (
     left_span_with_depth(i, depth),
     right_span_with_depth(i, depth),
@@ -259,7 +267,7 @@ pub fn spans(i: usize) -> (usize, usize) {
 }
 
 /// Returns how many nodes are in the tree that the node spans, with a depth.
-pub fn count_with_depth(_: usize, depth: usize) -> usize {
+fn count_with_depth(_: usize, depth: usize) -> usize {
   (2 << depth) - 1
 }
 
@@ -343,40 +351,47 @@ pub fn full_roots(i: usize, nodes: &mut Vec<usize>) {
 pub(crate) fn is_even(num: usize) -> bool {
   (num & 1) == 0
 }
-#[test]
-fn test_is_even() {
-  assert_eq!(is_even(0), true);
-  assert_eq!(is_even(1), false);
-  assert_eq!(is_even(2), true);
-  assert_eq!(is_even(3), false);
-}
 
 #[inline]
 pub(crate) fn is_odd(num: usize) -> bool {
   (num & 1) != 0
 }
-#[test]
-fn test_is_odd() {
-  assert_eq!(is_odd(0), false);
-  assert_eq!(is_odd(1), true);
-  assert_eq!(is_odd(2), false);
-  assert_eq!(is_odd(3), true);
-}
 
-#[test]
-fn test_parent_gt_int32() {
-  assert_eq!(parent(10_000_000_000), 10_000_000_001);
-}
+#[cfg(test)]
+mod tests {
+  use super::*;
 
-#[test]
-fn test_child_to_parent_to_child() {
-  let mut child = 0;
-  for _ in 0..50 {
-    child = parent(child)
+  #[test]
+  fn test_is_even() {
+    assert_eq!(is_even(0), true);
+    assert_eq!(is_even(1), false);
+    assert_eq!(is_even(2), true);
+    assert_eq!(is_even(3), false);
   }
-  assert_eq!(child, 1_125_899_906_842_623);
-  for _ in 0..50 {
-    child = left_child(child).expect("no valid number returned");
+
+  #[test]
+  fn test_is_odd() {
+    assert_eq!(is_odd(0), false);
+    assert_eq!(is_odd(1), true);
+    assert_eq!(is_odd(2), false);
+    assert_eq!(is_odd(3), true);
   }
-  assert_eq!(child, 0);
+
+  #[test]
+  fn test_parent_gt_int32() {
+    assert_eq!(parent(10_000_000_000), 10_000_000_001);
+  }
+
+  #[test]
+  fn test_child_to_parent_to_child() {
+    let mut child = 0;
+    for _ in 0..50 {
+      child = parent(child)
+    }
+    assert_eq!(child, 1_125_899_906_842_623);
+    for _ in 0..50 {
+      child = left_child(child).expect("no valid number returned");
+    }
+    assert_eq!(child, 0);
+  }
 }


### PR DESCRIPTION
Changes:
1. adds `debug_assert` to `*_with_depth` functions to ensure that provided depth is valid
1. adds missing doctests
1. moves unit tests to `tests` module with `#[cfg(test)]` as described [here](https://doc.rust-lang.org/book/second-edition/ch11-03-test-organization.html#the-tests-module-and-cfgtest)