### PR TITLE
inline all methods

### DIFF
--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -26,6 +26,7 @@ impl Iterator {
   /// use flat_tree::Iterator;
   /// assert_eq!(Iterator::new(0).take(3).collect::<Vec<usize>>(), [2, 4, 6]);
   /// ```
+  #[inline]
   pub fn new(index: usize) -> Self {
     let mut instance = Self {
       index: 0,
@@ -59,6 +60,7 @@ impl Iterator {
   /// iter.seek(2);
   /// assert_eq!(iter.next(), Some(4));
   /// ```
+  #[inline]
   pub fn seek(&mut self, index: usize) {
     self.index = index;
     if is_odd(self.index) {
@@ -105,6 +107,7 @@ impl Iterator {
   /// assert_eq!(iter.prev(), 2);
   /// assert_eq!(iter.prev(), 0);
   /// ```
+  #[inline]
   pub fn prev(&mut self) -> usize {
     if self.offset == 0 {
       return self.index;
@@ -122,6 +125,7 @@ impl Iterator {
   /// assert_eq!(flat_tree::Iterator::new(1).sibling(), 5);
   /// assert_eq!(flat_tree::Iterator::new(4).sibling(), 6);
   /// ```
+  #[inline]
   pub fn sibling(&mut self) -> usize {
     if self.is_left() {
       self.next().unwrap() // this is always safe
@@ -138,6 +142,7 @@ impl Iterator {
   /// assert_eq!(flat_tree::Iterator::new(1).parent(), 3);
   /// assert_eq!(flat_tree::Iterator::new(4).parent(), 5);
   /// ```
+  #[inline]
   pub fn parent(&mut self) -> usize {
     if is_odd(self.offset) {
       self.index -= self.factor / 2;
@@ -160,6 +165,7 @@ impl Iterator {
   /// assert_eq!(flat_tree::Iterator::new(23).left_span(), 16);
   /// assert_eq!(flat_tree::Iterator::new(27).left_span(), 24);
   /// ```
+  #[inline]
   pub fn left_span(&mut self) -> usize {
     self.index = self.index + 1 - self.factor / 2;
     self.offset = self.index / 2;
@@ -177,6 +183,7 @@ impl Iterator {
   /// assert_eq!(flat_tree::Iterator::new(23).right_span(), 30);
   /// assert_eq!(flat_tree::Iterator::new(27).right_span(), 30);
   /// ```
+  #[inline]
   pub fn right_span(&mut self) -> usize {
     self.index = self.index + self.factor / 2 - 1;
     self.offset = self.index / 2;
@@ -192,6 +199,7 @@ impl Iterator {
   /// assert_eq!(flat_tree::Iterator::new(3).left_child(), 1);
   /// assert_eq!(flat_tree::Iterator::new(7).left_child(), 3);
   /// ```
+  #[inline]
   pub fn left_child(&mut self) -> usize {
     if self.factor == 2 {
       return self.index;
@@ -210,6 +218,7 @@ impl Iterator {
   /// assert_eq!(flat_tree::Iterator::new(3).right_child(), 5);
   /// assert_eq!(flat_tree::Iterator::new(7).right_child(), 11);
   /// ```
+  #[inline]
   pub fn right_child(&mut self) -> usize {
     if self.factor == 2 {
       return self.index;
@@ -224,6 +233,7 @@ impl Iterator {
 impl iter::Iterator for Iterator {
   type Item = usize;
 
+  #[inline]
   fn next(&mut self) -> Option<Self::Item> {
     self.offset += 1;
     self.index += self.factor;
@@ -232,11 +242,13 @@ impl iter::Iterator for Iterator {
 }
 
 impl Default for Iterator {
+  #[inline]
   fn default() -> Self {
     Self::new(0)
   }
 }
 
+#[inline]
 fn two_pow(n: usize) -> usize {
   if n < 31 {
     1 << n

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub use iterator::Iterator;
 /// assert_eq!(flat_tree::index(3, 0), 7);
 /// assert_eq!(flat_tree::index(3, 1), 23);
 /// ```
+#[inline]
 pub fn index(depth: usize, offset: usize) -> usize {
   (offset << (depth + 1)) | ((1 << depth) - 1)
 }
@@ -34,6 +35,7 @@ pub fn index(depth: usize, offset: usize) -> usize {
 /// assert_eq!(flat_tree::depth(3), 2);
 /// assert_eq!(flat_tree::depth(4), 0);
 /// ```
+#[inline]
 pub fn depth(i: usize) -> usize {
   let mut depth = 0;
   let mut i = i;
@@ -54,6 +56,7 @@ pub fn depth(i: usize) -> usize {
 /// assert_eq!(flat_tree::offset_with_depth(3, 2), 0);
 /// assert_eq!(flat_tree::offset_with_depth(4, 0), 2);
 /// ```
+#[inline]
 pub fn offset_with_depth(i: usize, depth: usize) -> usize {
   debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   if is_even(i) {
@@ -73,6 +76,7 @@ pub fn offset_with_depth(i: usize, depth: usize) -> usize {
 /// assert_eq!(flat_tree::offset(3), 0);
 /// assert_eq!(flat_tree::offset(4), 2);
 /// ```
+#[inline]
 pub fn offset(i: usize) -> usize {
   offset_with_depth(i, depth(i))
 }
@@ -87,6 +91,7 @@ pub fn offset(i: usize) -> usize {
 /// assert_eq!(flat_tree::parent_with_depth(3, 2), 7);
 /// assert_eq!(flat_tree::parent_with_depth(4, 0), 5);
 /// ```
+#[inline]
 pub fn parent_with_depth(i: usize, depth: usize) -> usize {
   debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   index(depth + 1, offset_with_depth(i, depth) >> 1)
@@ -104,6 +109,7 @@ pub fn parent_with_depth(i: usize, depth: usize) -> usize {
 /// assert_eq!(flat_tree::parent(2), 1);
 /// assert_eq!(flat_tree::parent(1), 3);
 /// ```
+#[inline]
 pub fn parent(i: usize) -> usize {
   parent_with_depth(i, depth(i))
 }
@@ -118,6 +124,7 @@ pub fn parent(i: usize) -> usize {
 /// assert_eq!(flat_tree::sibling_with_depth(3, 2), 11);
 /// assert_eq!(flat_tree::sibling_with_depth(4, 0), 6);
 /// ```
+#[inline]
 pub fn sibling_with_depth(i: usize, depth: usize) -> usize {
   debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   index(depth, offset(i) ^ 1)
@@ -132,6 +139,7 @@ pub fn sibling_with_depth(i: usize, depth: usize) -> usize {
 /// assert_eq!(flat_tree::sibling(1), 5);
 /// assert_eq!(flat_tree::sibling(5), 1);
 /// ```
+#[inline]
 pub fn sibling(i: usize) -> usize {
   sibling_with_depth(i, depth(i))
 }
@@ -145,6 +153,7 @@ pub fn sibling(i: usize) -> usize {
 /// assert_eq!(flat_tree::uncle_with_depth(2, 0), 5);
 /// assert_eq!(flat_tree::uncle_with_depth(5, 1), 11);
 /// ```
+#[inline]
 pub fn uncle_with_depth(i: usize, depth: usize) -> usize {
   debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   sibling_with_depth(parent_with_depth(i, depth), depth + 1)
@@ -159,6 +168,7 @@ pub fn uncle_with_depth(i: usize, depth: usize) -> usize {
 /// assert_eq!(flat_tree::uncle(1), 11);
 /// assert_eq!(flat_tree::uncle(5), 11);
 /// ```
+#[inline]
 pub fn uncle(i: usize) -> usize {
   uncle_with_depth(i, depth(i))
 }
@@ -172,6 +182,7 @@ pub fn uncle(i: usize) -> usize {
 /// assert_eq!(flat_tree::children_with_depth(3, 2), Some((1, 5)));
 /// assert_eq!(flat_tree::children_with_depth(9, 1), Some((8, 10)));
 /// ```
+#[inline]
 pub fn children_with_depth(i: usize, depth: usize) -> Option<(usize, usize)> {
   debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   if is_even(i) {
@@ -193,6 +204,7 @@ pub fn children_with_depth(i: usize, depth: usize) -> Option<(usize, usize)> {
 /// assert_eq!(flat_tree::children(3), Some((1, 5)));
 /// assert_eq!(flat_tree::children(9), Some((8, 10)));
 /// ```
+#[inline]
 pub fn children(i: usize) -> Option<(usize, usize)> {
   children_with_depth(i, depth(i))
 }
@@ -206,6 +218,7 @@ pub fn children(i: usize) -> Option<(usize, usize)> {
 /// assert_eq!(flat_tree::left_child_with_depth(3, 2), Some(1));
 /// ```
 // TODO: handle errors
+#[inline]
 pub fn left_child_with_depth(i: usize, depth: usize) -> Option<usize> {
   debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   if is_even(i) {
@@ -225,6 +238,7 @@ pub fn left_child_with_depth(i: usize, depth: usize) -> Option<usize> {
 /// assert_eq!(flat_tree::left_child(1), Some(0));
 /// assert_eq!(flat_tree::left_child(3), Some(1));
 /// ```
+#[inline]
 pub fn left_child(i: usize) -> Option<usize> {
   left_child_with_depth(i, depth(i))
 }
@@ -237,6 +251,7 @@ pub fn left_child(i: usize) -> Option<usize> {
 /// assert_eq!(flat_tree::right_child_with_depth(1, 1), Some(2));
 /// assert_eq!(flat_tree::right_child_with_depth(3, 2), Some(5));
 /// ```
+#[inline]
 pub fn right_child_with_depth(i: usize, depth: usize) -> Option<usize> {
   debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   if is_even(i) {
@@ -257,6 +272,7 @@ pub fn right_child_with_depth(i: usize, depth: usize) -> Option<usize> {
 /// assert_eq!(flat_tree::right_child(3), Some(5));
 /// ```
 // TODO: handle errors
+#[inline]
 pub fn right_child(i: usize) -> Option<usize> {
   right_child_with_depth(i, depth(i))
 }
@@ -271,6 +287,7 @@ pub fn right_child(i: usize) -> Option<usize> {
 /// assert_eq!(flat_tree::right_span_with_depth(23, 3), 30);
 /// assert_eq!(flat_tree::right_span_with_depth(27, 2), 30);
 /// ```
+#[inline]
 pub fn right_span_with_depth(i: usize, depth: usize) -> usize {
   debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   if depth == 0 {
@@ -290,6 +307,7 @@ pub fn right_span_with_depth(i: usize, depth: usize) -> usize {
 /// assert_eq!(flat_tree::right_span(23), 30);
 /// assert_eq!(flat_tree::right_span(27), 30);
 /// ```
+#[inline]
 pub fn right_span(i: usize) -> usize {
   right_span_with_depth(i, depth(i))
 }
@@ -304,6 +322,7 @@ pub fn right_span(i: usize) -> usize {
 /// assert_eq!(flat_tree::left_span_with_depth(23, 3), 16);
 /// assert_eq!(flat_tree::left_span_with_depth(27, 2), 24);
 /// ```
+#[inline]
 pub fn left_span_with_depth(i: usize, depth: usize) -> usize {
   debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   if depth == 0 {
@@ -323,6 +342,7 @@ pub fn left_span_with_depth(i: usize, depth: usize) -> usize {
 /// assert_eq!(flat_tree::left_span(23), 16);
 /// assert_eq!(flat_tree::left_span(27), 24);
 /// ```
+#[inline]
 pub fn left_span(i: usize) -> usize {
   left_span_with_depth(i, depth(i))
 }
@@ -338,6 +358,7 @@ pub fn left_span(i: usize) -> usize {
 /// assert_eq!(flat_tree::spans_with_depth(23, 3), (16, 30));
 /// assert_eq!(flat_tree::spans_with_depth(27, 2), (24, 30));
 /// ```
+#[inline]
 pub fn spans_with_depth(i: usize, depth: usize) -> (usize, usize) {
   debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   (
@@ -356,6 +377,7 @@ pub fn spans_with_depth(i: usize, depth: usize) -> (usize, usize) {
 /// assert_eq!(flat_tree::spans(23), (16, 30));
 /// assert_eq!(flat_tree::spans(27), (24, 30));
 /// ```
+#[inline]
 pub fn spans(i: usize) -> (usize, usize) {
   spans_with_depth(i, depth(i))
 }
@@ -371,6 +393,7 @@ pub fn spans(i: usize) -> (usize, usize) {
 /// assert_eq!(flat_tree::count_with_depth(23, 3), 15);
 /// assert_eq!(flat_tree::count_with_depth(27, 2), 7);
 /// ```
+#[inline]
 pub fn count_with_depth(i: usize, depth: usize) -> usize {
   debug_assert_eq!(depth, self::depth(i), "Invalid depth.");
   (2 << depth) - 1
@@ -387,6 +410,7 @@ pub fn count_with_depth(i: usize, depth: usize) -> usize {
 /// assert_eq!(flat_tree::count(23), 15);
 /// assert_eq!(flat_tree::count(27), 7);
 /// ```
+#[inline]
 pub fn count(i: usize) -> usize {
   count_with_depth(i, depth(i))
 }
@@ -426,6 +450,7 @@ pub fn count(i: usize) -> usize {
 /// full_roots(16, &mut nodes);
 /// assert_eq!(nodes, [7]);
 /// ```
+#[inline]
 pub fn full_roots(i: usize, nodes: &mut Vec<usize>) {
   assert!(
     is_even(i),


### PR DESCRIPTION
This recommends the compiler inline all methods, allowing it to significantly speed up operations. Note that this is different from `[inline(always)]` in that we're not forcing the compiler to inline, but merely hint it probably should, and enable it to do so across crate boundaries.

Thanks!