### PR TITLE
Change from usize to u64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ cache: cargo
 rust: stable
 
 before_script:
-  - rustup component add rustfmt-preview
-  - rustup component add clippy-preview
+  - rustup component add rustfmt
+  - rustup component add clippy
   - cargo fmt --version
   - cargo clippy --version
 
@@ -12,4 +12,4 @@ script:
   - cargo fmt -- --check
   - cargo build --verbose
   - cargo test  --verbose
-  - cargo clippy
+  - cargo clippy -- -D clippy::all

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -13,9 +13,9 @@ use std::iter;
 /// Iterator over a flat-tree.
 #[derive(Debug)]
 pub struct Iterator {
-  index: usize,
-  offset: usize,
-  factor: usize,
+  index: u64,
+  offset: u64,
+  factor: u64,
 }
 
 impl Iterator {
@@ -24,10 +24,10 @@ impl Iterator {
   /// ## Examples
   /// ```rust
   /// use flat_tree::Iterator;
-  /// assert_eq!(Iterator::new(0).take(3).collect::<Vec<usize>>(), [2, 4, 6]);
+  /// assert_eq!(Iterator::new(0).take(3).collect::<Vec<u64>>(), [2, 4, 6]);
   /// ```
   #[inline]
-  pub fn new(index: usize) -> Self {
+  pub fn new(index: u64) -> Self {
     let mut instance = Self {
       index: 0,
       offset: 0,
@@ -40,19 +40,19 @@ impl Iterator {
 
   /// Get the current index.
   #[inline]
-  pub fn index(&self) -> usize {
+  pub fn index(&self) -> u64 {
     self.index
   }
 
   /// Get the current offset.
   #[inline]
-  pub fn offset(&self) -> usize {
+  pub fn offset(&self) -> u64 {
     self.offset
   }
 
   /// Get the current factor.
   #[inline]
-  pub fn factor(&self) -> usize {
+  pub fn factor(&self) -> u64 {
     self.factor
   }
 
@@ -67,7 +67,7 @@ impl Iterator {
   /// assert_eq!(iter.next(), Some(4));
   /// ```
   #[inline]
-  pub fn seek(&mut self, index: usize) {
+  pub fn seek(&mut self, index: u64) {
     self.index = index;
     if is_odd(self.index) {
       self.offset = offset(index);
@@ -114,7 +114,7 @@ impl Iterator {
   /// assert_eq!(iter.prev(), 0);
   /// ```
   #[inline]
-  pub fn prev(&mut self) -> usize {
+  pub fn prev(&mut self) -> u64 {
     if self.offset == 0 {
       return self.index;
     }
@@ -132,7 +132,7 @@ impl Iterator {
   /// assert_eq!(flat_tree::Iterator::new(4).sibling(), 6);
   /// ```
   #[inline]
-  pub fn sibling(&mut self) -> usize {
+  pub fn sibling(&mut self) -> u64 {
     if self.is_left() {
       self.next().unwrap() // this is always safe
     } else {
@@ -149,7 +149,7 @@ impl Iterator {
   /// assert_eq!(flat_tree::Iterator::new(4).parent(), 5);
   /// ```
   #[inline]
-  pub fn parent(&mut self) -> usize {
+  pub fn parent(&mut self) -> u64 {
     if is_odd(self.offset) {
       self.index -= self.factor / 2;
       self.offset = (self.offset - 1) / 2;
@@ -172,7 +172,7 @@ impl Iterator {
   /// assert_eq!(flat_tree::Iterator::new(27).left_span(), 24);
   /// ```
   #[inline]
-  pub fn left_span(&mut self) -> usize {
+  pub fn left_span(&mut self) -> u64 {
     self.index = self.index + 1 - self.factor / 2;
     self.offset = self.index / 2;
     self.factor = 2;
@@ -190,7 +190,7 @@ impl Iterator {
   /// assert_eq!(flat_tree::Iterator::new(27).right_span(), 30);
   /// ```
   #[inline]
-  pub fn right_span(&mut self) -> usize {
+  pub fn right_span(&mut self) -> u64 {
     self.index = self.index + self.factor / 2 - 1;
     self.offset = self.index / 2;
     self.factor = 2;
@@ -206,7 +206,7 @@ impl Iterator {
   /// assert_eq!(flat_tree::Iterator::new(7).left_child(), 3);
   /// ```
   #[inline]
-  pub fn left_child(&mut self) -> usize {
+  pub fn left_child(&mut self) -> u64 {
     if self.factor == 2 {
       return self.index;
     }
@@ -225,7 +225,7 @@ impl Iterator {
   /// assert_eq!(flat_tree::Iterator::new(7).right_child(), 11);
   /// ```
   #[inline]
-  pub fn right_child(&mut self) -> usize {
+  pub fn right_child(&mut self) -> u64 {
     if self.factor == 2 {
       return self.index;
     }
@@ -237,7 +237,7 @@ impl Iterator {
 }
 
 impl iter::Iterator for Iterator {
-  type Item = usize;
+  type Item = u64;
 
   #[inline]
   fn next(&mut self) -> Option<Self::Item> {
@@ -255,7 +255,7 @@ impl Default for Iterator {
 }
 
 #[inline]
-fn two_pow(n: usize) -> usize {
+fn two_pow(n: u64) -> u64 {
   if n < 31 {
     1 << n
   } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use iterator::Iterator;
 /// assert_eq!(flat_tree::index(3, 1), 23);
 /// ```
 #[inline]
-pub const fn index(depth: usize, offset: usize) -> usize {
+pub const fn index(depth: u64, offset: u64) -> u64 {
   (offset << (depth + 1)) | ((1 << depth) - 1)
 }
 
@@ -36,9 +36,9 @@ pub const fn index(depth: usize, offset: usize) -> usize {
 /// assert_eq!(flat_tree::depth(4), 0);
 /// ```
 #[inline]
-pub const fn depth(i: usize) -> usize {
+pub const fn depth(i: u64) -> u64 {
   // Count trailing `1`s of the binary representation of the number.
-  (!i).trailing_zeros() as usize
+  (!i).trailing_zeros() as u64
 }
 
 /// Returns the offset of a node.
@@ -52,7 +52,7 @@ pub const fn depth(i: usize) -> usize {
 /// assert_eq!(flat_tree::offset(4), 2);
 /// ```
 #[inline]
-pub fn offset(i: usize) -> usize {
+pub fn offset(i: u64) -> u64 {
   let depth = self::depth(i);
   if is_even(i) {
     i / 2
@@ -72,7 +72,7 @@ pub fn offset(i: usize) -> usize {
 /// assert_eq!(flat_tree::parent(4), 5);
 /// ```
 #[inline]
-pub fn parent(i: usize) -> usize {
+pub fn parent(i: u64) -> u64 {
   let depth = self::depth(i);
   index(depth + 1, offset(i) >> 1)
 }
@@ -87,7 +87,7 @@ pub fn parent(i: usize) -> usize {
 /// assert_eq!(flat_tree::sibling(5), 1);
 /// ```
 #[inline]
-pub fn sibling(i: usize) -> usize {
+pub fn sibling(i: u64) -> u64 {
   let depth = self::depth(i);
   index(depth, offset(i) ^ 1)
 }
@@ -102,7 +102,7 @@ pub fn sibling(i: usize) -> usize {
 /// assert_eq!(flat_tree::uncle(5), 11);
 /// ```
 #[inline]
-pub fn uncle(i: usize) -> usize {
+pub fn uncle(i: u64) -> u64 {
   let depth = self::depth(i);
   index(depth + 1, offset(parent(i)) ^ 1)
 }
@@ -117,7 +117,7 @@ pub fn uncle(i: usize) -> usize {
 /// assert_eq!(flat_tree::children(9), Some((8, 10)));
 /// ```
 #[inline]
-pub fn children(i: usize) -> Option<(usize, usize)> {
+pub fn children(i: u64) -> Option<(u64, u64)> {
   let depth = self::depth(i);
   if is_even(i) {
     None
@@ -138,7 +138,7 @@ pub fn children(i: usize) -> Option<(usize, usize)> {
 /// assert_eq!(flat_tree::left_child(3), Some(1));
 /// ```
 #[inline]
-pub fn left_child(i: usize) -> Option<usize> {
+pub fn left_child(i: u64) -> Option<u64> {
   let depth = self::depth(i);
   if is_even(i) {
     None
@@ -159,7 +159,7 @@ pub fn left_child(i: usize) -> Option<usize> {
 /// ```
 // TODO: handle errors
 #[inline]
-pub fn right_child(i: usize) -> Option<usize> {
+pub fn right_child(i: u64) -> Option<u64> {
   let depth = self::depth(i);
   if is_even(i) {
     None
@@ -181,7 +181,7 @@ pub fn right_child(i: usize) -> Option<usize> {
 /// assert_eq!(flat_tree::right_span(27), 30);
 /// ```
 #[inline]
-pub fn right_span(i: usize) -> usize {
+pub fn right_span(i: u64) -> u64 {
   let depth = self::depth(i);
   if depth == 0 {
     i
@@ -201,7 +201,7 @@ pub fn right_span(i: usize) -> usize {
 /// assert_eq!(flat_tree::left_span(27), 24);
 /// ```
 #[inline]
-pub fn left_span(i: usize) -> usize {
+pub fn left_span(i: u64) -> u64 {
   let depth = self::depth(i);
   if depth == 0 {
     i
@@ -221,7 +221,7 @@ pub fn left_span(i: usize) -> usize {
 /// assert_eq!(flat_tree::spans(27), (24, 30));
 /// ```
 #[inline]
-pub fn spans(i: usize) -> (usize, usize) {
+pub fn spans(i: u64) -> (u64, u64) {
   (left_span(i), right_span(i))
 }
 
@@ -237,7 +237,7 @@ pub fn spans(i: usize) -> (usize, usize) {
 /// assert_eq!(flat_tree::count(27), 7);
 /// ```
 #[inline]
-pub const fn count(i: usize) -> usize {
+pub const fn count(i: u64) -> u64 {
   let depth = self::depth(i);
   (2 << depth) - 1
 }
@@ -281,7 +281,7 @@ pub const fn count(i: usize) -> usize {
 /// assert_eq!(nodes, [7]);
 /// ```
 #[inline]
-pub fn full_roots(i: usize, nodes: &mut Vec<usize>) {
+pub fn full_roots(i: u64, nodes: &mut Vec<u64>) {
   assert!(
     is_even(i),
     format!(
@@ -308,12 +308,12 @@ pub fn full_roots(i: usize, nodes: &mut Vec<usize>) {
 }
 
 #[inline]
-pub(crate) const fn is_even(num: usize) -> bool {
+pub(crate) const fn is_even(num: u64) -> bool {
   (num & 1) == 0
 }
 
 #[inline]
-pub(crate) const fn is_odd(num: usize) -> bool {
+pub(crate) const fn is_odd(num: u64) -> bool {
   (num & 1) != 0
 }
 


### PR DESCRIPTION
On [random-access-storage](https://github.com/datrs/random-access-storage) issue
https://github.com/datrs/random-access-storage/issues/6 has changed all
types from `usize` into `u64` to be able to handle more than 4gbs on
32bits systems.

> usize is 32 bits on a 32 bit system, so the storage would be limited
to 4GB on such a system.

When changing `random-access-storage` on `hypercore` (tracking:
https://github.com/datrs/hypercore/pull/100) one of the things I've
noticed is that it wold be easier to also make `flat-tree` use `u64` to
integrate with `random-access-storage`. Very likely, this also means
that we would need to bump to use more than 32Gb storages on
`flat-tree`.

I've simply changed all declarations of usize into u64. All tests are
passing.